### PR TITLE
fix: temp file cannot be deleted correctly on windows

### DIFF
--- a/pipelines/utils.py
+++ b/pipelines/utils.py
@@ -88,7 +88,10 @@ def save_video(video_tensor, audio_path, output_path, fps=30.0):
     cmd = (f'{get_ffmpeg_exe()} -i "{temp_output_path}" -i "{audio_path}" '
            f'-map 0:v -map 1:a -c:v h264 -shortest -y "{output_path}" -loglevel quiet')
     os.system(cmd)
-    os.system(f'rm -rf "{temp_output_path}"')
+
+    # Remove temporary video file
+    if os.path.exists(temp_output_path):
+        os.remove(temp_output_path)
 
 
 def compute_dist(x1, y1, x2, y2):


### PR DESCRIPTION
Obviously the “rm” command cannot work correctly on Windows. Cross-platform implementation should be used here.
