### PR TITLE
fix: resample audio waveform

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -7,7 +7,7 @@ import accelerate
 import cv2
 import numpy as np
 import torchaudio.functional
-import torchvision.io
+import torchaudio
 from PIL import Image
 from diffusers import AutoencoderKL, DDIMScheduler
 from diffusers.utils.import_utils import is_xformers_available
@@ -242,8 +242,7 @@ def main():
         del app
     torch.cuda.empty_cache()
 
-    _, audio_waveform, meta_info = torchvision.io.read_video(args.audio_path, pts_unit='sec')
-    audio_sampling_rate = meta_info['audio_fps']
+    audio_waveform, audio_sampling_rate = torchaudio.load(args.audio_path)
     print(f'Length of audio is {audio_waveform.shape[1]} with the sampling rate of {audio_sampling_rate}.')
     if audio_sampling_rate != args.standard_audio_sampling_rate:
         audio_waveform = torchaudio.functional.resample(


### PR DESCRIPTION
Thanks for the open source of this project. I found a bug when using audio with a sample rate not equal to 16000 (e.g. 48000) as input. 

The previous code used `torchvision.io.read_video`, this to used to read video files, not audio files. This will result in the type of `audio_waveform` being `torch.int`. And the input received by `torch.audio.functional.resample` should be `torch.float`. However, simple type conversion cannot solve the problem, and an intuitive consequence is that the generated video have **audio and visual asynchrony**, and the generated video duration will be longer than the original input audio.

A simple fix for this is to directly use `torchaudio.load`, as modified in the PR. Please consider merging this, as it will make this interesting project more robust and stable when facing audio inputs of different sample rates.